### PR TITLE
Allow the engine to use a native configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,8 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.3.10" withSources(),
   "org.scala-lang.modules" %% "scala-xml" % "1.0.5" withSources(),
-  "com.codacy" %% "codacy-engine-scala-seed" % "2.6.31"
+  "com.codacy" %% "codacy-engine-scala-seed" % "2.7.1",
+  "com.github.pathikrit" %% "better-files" % "2.16.0"
 )
 
 enablePlugins(JavaAppPackaging)

--- a/src/main/resources/docs/scalastyle_config.xml
+++ b/src/main/resources/docs/scalastyle_config.xml
@@ -1,0 +1,191 @@
+<scalastyle commentFilter="enabled">
+    <name>Scalastyle standard configuration</name>
+    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxFileLength">
+                <![CDATA[ 800 ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+        <parameters>
+            <parameter name="header">
+                <![CDATA[
+                // Copyright (C) 2011-2012 the original author or authors. // See the LICENCE.txt file distributed with this work for additional // information regarding copyright ownership. // // Licensed under the Apache License, Version 2.0 (the "License"); // you may not use this file except in compliance with the License. // You may obtain a copy of the License at // // http://www.apache.org/licenses/LICENSE-2.0 // // Unless required by applicable law or agreed to in writing, software // distributed under the License is distributed on an "AS IS" BASIS, // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. // See the License for the specific language governing permissions and // limitations under the License.
+                ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLineLength">
+                <![CDATA[ 160 ]]>
+            </parameter>
+            <parameter name="tabSize">
+                <![CDATA[ 4 ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex">
+                <![CDATA[^[A-Z][A-Za-z0-9]*$]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex">
+                <![CDATA[^[A-Z][A-Za-z0-9]*$]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex">
+                <![CDATA[^[a-z][A-Za-z0-9]*$]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+        <parameters>
+            <parameter name="illegalImports">
+                <![CDATA[ sun._,java.awt._ ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="maxParameters">
+                <![CDATA[ 8 ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="ignore">
+                <![CDATA[ -1,0,1,2,3 ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="true">
+        <parameters>
+            <parameter name="regex">
+                <![CDATA[ println ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+        <parameters>
+            <parameter name="maxTypes">
+                <![CDATA[ 30 ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="true">
+        <parameters>
+            <parameter name="maximum">
+                <![CDATA[ 10 ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
+        <parameters>
+            <parameter name="singleLineAllowed">
+                <![CDATA[ true ]]>
+            </parameter>
+            <parameter name="doubleLineAllowed">
+                <![CDATA[ false ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLength">
+                <![CDATA[ 50 ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex">
+                <![CDATA[^([a-z][A-Za-z0-9]*|<<|>>>|>|==|!=|<|<=|>|>=|\||&|\^|\+|-|\*|\/|%|\|\||&&|\+\+|--|\+=|-=)$]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="true">
+        <parameters>
+            <parameter name="maxMethods">
+                <![CDATA[ 30 ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="true"/>
+
+    <check enabled="true" class="org.scalastyle.file.IndentationChecker" level="warning">
+        <parameters>
+            <parameter name="tabSize">2</parameter>
+        </parameters>
+    </check>
+    <check enabled="true" class="org.scalastyle.scalariform.NonASCIICharacterChecker" level="warning"/>
+    <check enabled="true" class="org.scalastyle.scalariform.FieldNamesChecker" level="warning">
+        <parameters>
+            <parameter name="regex">^[a-z][A-Za-z0-9]*$</parameter>
+        </parameters>
+    </check>
+    <check enabled="true" class="org.scalastyle.scalariform.XmlLiteralChecker" level="warning"/>
+    <check level="warning" class="org.scalastyle.scalariform.WhileChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="true">
+        <parameters>
+            <parameter name="regex">
+                <![CDATA[ println ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
+        <parameters>
+            <parameter name="regex">
+                <![CDATA[ ^[A-Z_]$ ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="true">
+        <parameters>
+            <parameter name="allowed">
+                <![CDATA[ 1 ]]>
+            </parameter>
+            <parameter name="ignoreRegex">
+                <![CDATA[ ^""$ ]]>
+            </parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="true"/>
+    <check level="warning" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ForBraceChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.BlockImportChecker" enabled="true"></check>
+</scalastyle>

--- a/src/main/scala/codacy/scalastyle/ScalaStyle.scala
+++ b/src/main/scala/codacy/scalastyle/ScalaStyle.scala
@@ -3,24 +3,32 @@ package codacy.scalastyle
 import java.io.File
 import java.nio.file.Path
 
-import codacy.dockerApi.utils.{CommandRunner, ToolHelper, FileHelper}
 import codacy.dockerApi._
+import codacy.dockerApi.utils.{CommandRunner, FileHelper, ToolHelper}
 import play.api.libs.json.{JsString, JsValue}
 
 import scala.util.Try
-import scala.xml.{Node, Elem}
+import scala.xml.{Elem, Node,XML}
 
 object ScalaStyle extends Tool {
 
   override def apply(path: Path, conf: Option[List[PatternDef]], files: Option[Set[Path]])(implicit spec: Spec): Try[List[Result]] = {
     Try {
+
+      lazy val nativeConfigFile: Option[File] = {
+        configFileNames.to[Stream].map( name => better.files.File(path) / name ).find(_.isRegularFile).map(_.toJava)
+      }
+
       val fullConf = ToolHelper.getPatternsToLint(conf)
       val filesToLint: List[String] = files.fold(List(path.toString)) {
         paths =>
           paths.map(_.toString).toList
       }
 
-      val configuration = List("--config", getConfigFile(fullConf).getAbsolutePath.toString)
+      val configuration = List("--config",
+        //priorities: codacy-patterns then a native config in the project-root then the default config
+        getConfigFile(fullConf).orElse(nativeConfigFile).getOrElse(defaultConfigFile).getAbsolutePath
+      )
 
       val command = List("java", "-jar", "/opt/docker/scalastyle.jar") ++ configuration ++ filesToLint
 
@@ -32,7 +40,16 @@ object ScalaStyle extends Tool {
     }
   }
 
-  def parseToolResult(lines: List[String], path: Path): List[Result] = {
+  private lazy val configFileName = "scalastyle_config.xml"
+  private lazy val configFileNames = List(configFileName, "scalastyle-config.xml")
+
+  private lazy val defaultConfigFile: File = {
+    (better.files.File.root / "docs" / configFileName).toJava
+  }
+
+  private lazy val scalaStyleConfig: Elem = XML.loadFile(defaultConfigFile)
+
+  private def parseToolResult(lines: List[String], path: Path): List[Result] = {
 
     val RegMatch = """([a-z]+) file=(.+) id=(.+) message=(.+) line=([0-9]+).*$""".r
     val FileErrorMatch = """^error file=(.+) message=(.+)""".r
@@ -48,201 +65,7 @@ object ScalaStyle extends Tool {
     }
   }
 
-  private lazy val scalaStyleConfig: Elem =
-    <scalastyle commentFilter="enabled">
-      <name>Scalastyle standard configuration</name>
-      <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="false">
-        <parameters>
-          <parameter name="maxFileLength">
-            <![CDATA[ 800 ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">
-        <parameters>
-          <parameter name="header">
-            <![CDATA[
-                // Copyright (C) 2011-2012 the original author or authors. // See the LICENCE.txt file distributed with this work for additional // information regarding copyright ownership. // // Licensed under the Apache License, Version 2.0 (the "License"); // you may not use this file except in compliance with the License. // You may obtain a copy of the License at // // http://www.apache.org/licenses/LICENSE-2.0 // // Unless required by applicable law or agreed to in writing, software // distributed under the License is distributed on an "AS IS" BASIS, // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. // See the License for the specific language governing permissions and // limitations under the License.
-                ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="false">
-        <parameters>
-          <parameter name="maxLineLength">
-            <![CDATA[ 160 ]]>
-          </parameter>
-          <parameter name="tabSize">
-            <![CDATA[ 4 ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="false">
-        <parameters>
-          <parameter name="regex">
-            <![CDATA[^[A-Z][A-Za-z0-9]*$]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="false">
-        <parameters>
-          <parameter name="regex">
-            <![CDATA[^[A-Z][A-Za-z0-9]*$]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="false">
-        <parameters>
-          <parameter name="regex">
-            <![CDATA[^[a-z][A-Za-z0-9]*$]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="false">
-        <parameters>
-          <parameter name="illegalImports">
-            <![CDATA[ sun._,java.awt._ ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="false">
-        <parameters>
-          <parameter name="maxParameters">
-            <![CDATA[ 8 ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false">
-        <parameters>
-          <parameter name="ignore">
-            <![CDATA[ -1,0,1,2,3 ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"/>
-      <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="false">
-        <parameters>
-          <parameter name="regex">
-            <![CDATA[ println ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="false">
-        <parameters>
-          <parameter name="maxTypes">
-            <![CDATA[ 30 ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false">
-        <parameters>
-          <parameter name="maximum">
-            <![CDATA[ 10 ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="false">
-        <parameters>
-          <parameter name="singleLineAllowed">
-            <![CDATA[ true ]]>
-          </parameter>
-          <parameter name="doubleLineAllowed">
-            <![CDATA[ false ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="false">
-        <parameters>
-          <parameter name="maxLength">
-            <![CDATA[ 50 ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="false">
-        <parameters>
-          <parameter name="regex">
-            <![CDATA[^([a-z][A-Za-z0-9]*|<<|>>>|>|==|!=|<|<=|>|>=|\||&|\^|\+|-|\*|\/|%|\|\||&&|\+\+|--|\+=|-=)$]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="false">
-        <parameters>
-          <parameter name="maxMethods">
-            <![CDATA[ 30 ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"/>
-
-      <check enabled="false" class="org.scalastyle.file.IndentationChecker" level="warning">
-        <parameters>
-          <parameter name="tabSize">2</parameter>
-        </parameters>
-      </check>
-      <check enabled="false" class="org.scalastyle.scalariform.NonASCIICharacterChecker" level="warning"/>
-      <check enabled="false" class="org.scalastyle.scalariform.FieldNamesChecker" level="warning">
-        <parameters>
-          <parameter name="regex">^[a-z][A-Za-z0-9]*$</parameter>
-        </parameters>
-      </check>
-      <check enabled="false" class="org.scalastyle.scalariform.XmlLiteralChecker" level="warning"/>
-      <check level="warning" class="org.scalastyle.scalariform.WhileChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.VarFieldChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.VarLocalChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.RedundantIfChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.TokenChecker" enabled="false">
-        <parameters>
-          <parameter name="regex">
-            <![CDATA[ println ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.DeprecatedJavaChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="false">
-        <parameters>
-          <parameter name="regex">
-            <![CDATA[ ^[A-Z_]$ ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" enabled="false">
-        <parameters>
-          <parameter name="allowed">
-            <![CDATA[ 1 ]]>
-          </parameter>
-          <parameter name="ignoreRegex">
-            <![CDATA[ ^""$ ]]>
-          </parameter>
-        </parameters>
-      </check>
-      <check level="warning" class="org.scalastyle.scalariform.ImportGroupingChecker" enabled="false"/>
-      <check level="warning" class="org.scalastyle.scalariform.ProcedureDeclarationChecker" enabled="false"></check>
-      <check level="warning" class="org.scalastyle.scalariform.NotImplementedErrorUsage" enabled="false"></check>
-      <check level="warning" class="org.scalastyle.scalariform.ForBraceChecker" enabled="false"></check>
-      <check level="warning" class="org.scalastyle.scalariform.BlockImportChecker" enabled="false"></check>
-    </scalastyle>
-
-
-  private def getConfigFile(conf: Option[List[PatternDef]]): File = {
+  private def getConfigFile(conf: Option[List[PatternDef]]): Option[File] = {
     val customConfig = conf.map {
       patterns =>
 
@@ -267,12 +90,10 @@ object ScalaStyle extends Tool {
         }
     }
 
-    val scalaStyleNewConfig = customConfig.fold(scalaStyleConfig.mkString) {
-      case newConf =>
-        "<scalastyle>" + newConf.mkString + "</scalastyle>"
+    customConfig.map { case newConf =>
+      val scalaStyleNewConfig = "<scalastyle>" + newConf.mkString + "</scalastyle>"
+      FileHelper.createTmpFile(scalaStyleNewConfig).toFile
     }
-
-    FileHelper.createTmpFile(scalaStyleNewConfig).toFile
   }
 
   private def jsValueToString(value: JsValue) = {


### PR DESCRIPTION
-- in the case of scalastyle a configuration is mandatory.
so the engine can either be called with codacy-parameters (as before)
or it can contain a file 'scalastyle_config.xml' or 'scalastyle-config.xml' in the project root (native)
or the default configuration will be used